### PR TITLE
dryrun mode for member/team mapping without scim

### DIFF
--- a/CH_sentry_projects_teams_mapping.py
+++ b/CH_sentry_projects_teams_mapping.py
@@ -40,7 +40,7 @@ class Sentry():
         """Return a list of project slugs in this Sentry org"""
 
         results = self._get_api_pagination(f'/api/0/organizations/{self.org}/projects/')
-
+    
         return [project.get('slug', '') for project in results]
 
     def get_teams(self):
@@ -57,8 +57,13 @@ class Sentry():
 
     def give_team_access_to_project(self, team, project):
         """Give a team access to a project"""
-
+       
         return self._post_api(f'/api/0/projects/{self.org}/{project}/teams/{team}/')
+    
+    def get_projects(self):
+        results = self._get_api_pagination(f'/api/0/organizations/{self.org}/projects/')
+        
+        return [project.get('slug', '') for project in results]
 
 
 def get_team_projects(teams):
@@ -68,11 +73,10 @@ def get_team_projects(teams):
 
     return mapping
 
-
 if __name__ == '__main__':
+
     onpremise_token = os.environ['SENTRY_ONPREMISE_AUTH_TOKEN']
     cloud_token = os.environ['SENTRY_CLOUD_AUTH_TOKEN']
-
     # copy over onpremise url (e.g. http://sentry.yourcompany.com)
     sentry_onpremise = Sentry('<ON_PREMISE_URL>',
                               '<ON_PREMISE_ORG_SLUG>',
@@ -85,19 +89,25 @@ if __name__ == '__main__':
     cloud_teams = sentry_cloud.get_teams()
 
     onpremise_projects = get_team_projects(onpremise_teams)
+    
     cloud_projects = get_team_projects(cloud_teams)
-
-    # If a team is in onpremise, but not cloud, it should be added to cloud
+    
+    #If a team is in onpremise, but not cloud, it should be added to cloud
     missing_teams = onpremise_teams.keys() - cloud_teams.keys()
     for team in missing_teams:
-        print(f'Creating mising team {team}: ')
+        print(f'Creating missing team {team}: ')
         sentry_cloud.create_team(onpremise_teams[team]['name'], onpremise_teams[team]['slug'])
         cloud_projects[team] = set()
 
-    # If a team exists in both, grant any missing project access in cloud
+    # If a team exists in both, grant access to any missing project in cloud
     common_teams = onpremise_projects.keys() & cloud_projects.keys()
+    cloud_projects_list = sentry_cloud.get_projects()
+    
     for team in common_teams:
-        missing_projects = onpremise_projects[team] - cloud_projects[team]
-        for project in missing_projects:
-            print(f'Granting team {team} missing access to project {project}: ')
-            sentry_cloud.give_team_access_to_project(team, project)
+        onpremise_team_projects = onpremise_projects[team]
+        for op in onpremise_team_projects:
+            for cp in cloud_projects_list:
+                if op in cp:
+                    # adds mapping to the team.
+                    sentry_cloud.give_team_access_to_project(team, cp)
+                    #print("adding mapping of project "+ cp + " to team: " + team)

--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ Additionally, please make sure to change the following in the script to match yo
 - `<ORG_SLUG>`
 
 For the following script, `sentry_member_team_map.py`, you will need to have Python3 to run.  It was tested scucessfully with Python3.7.  
+
+The permissions you will need for your internal integration that will generate the necessary auth tokens are shown below:
+

--- a/get_issues_with_pagination.py
+++ b/get_issues_with_pagination.py
@@ -1,0 +1,47 @@
+
+import os
+import sys
+
+import requests
+
+
+class Sentry():
+    def __init__(self, base_url, org, token):
+        self.base_url = base_url
+        self.org = org
+        self.token = token
+
+    def _get_api_pagination(self, endpoint):
+        """HTTP GET the Sentry API, following pagination links"""
+
+        headers = {'Authorization': f'Bearer {self.token}'}
+ 
+        results = []
+        url = f'{self.base_url}{endpoint}'
+        next = True
+        while next:
+            response = requests.get(url, headers=headers)
+            results.extend(response.json())
+            url = response.links.get('next', {}).get('url')
+            next = response.links.get('next', {}).get('results') == 'true'
+
+        return results
+        
+    def get_issues(self):
+        results = self._get_api_pagination(f'/api/0/projects/healthsherpa/healthsherpa/issues/')
+        return results
+
+
+if __name__ == '__main__':
+    
+    os.environ['SENTRY_CLOUD_AUTH_TOKEN'] = ''
+    cloud_token = os.environ['SENTRY_CLOUD_AUTH_TOKEN']
+   
+    sentry_cloud = Sentry('https://sentry.io',
+                          '<ORG_SLUG>',
+                          cloud_token)
+
+    sentry_response = sentry_cloud.get_issues() 
+    print(sentry_response)
+    
+

--- a/merge_multiple_self_hosted_instances/README.md
+++ b/merge_multiple_self_hosted_instances/README.md
@@ -1,0 +1,10 @@
+# Merge multiple self-hosted instances together
+
+Inside this directory are 2 scripts:
+
+1. Script that takes two export JSON files, each from a different self-hosted instance, and merges them into a single export JSON file. This script is expected to be run by Sentry SEs, and not by our customers. That JSON file should then be given to the Sentry ops team to complete the migration.
+2. The "comparer" script validates the merged JSON file.
+
+Note:
+- These scripts have been used in real migrations, but are not exhaustively tested. You are encouraged to do some spot checking on the output merged JSON file to make sure things look good and records are associated correctly.
+- The migration process run by the ops team (in any scenario, not just merging multiple self-hosted instances) does not carry over all data included in the original JSON export file. So, the merge script only combines certain types of data: Alerts, Projects, Project Options, Teams, Organization. If you are reading the script and wondering why it doesn't carry over everything, that's why.

--- a/merge_multiple_self_hosted_instances/comparer.rb
+++ b/merge_multiple_self_hosted_instances/comparer.rb
@@ -1,0 +1,267 @@
+require 'json'
+require 'pry'
+
+class Comparer
+	attr_reader :prod_data, :merged_data, :staging_data
+	def initialize
+=begin
+		@prod_data 	= JSON.parse(File.read('first_import/sentry_export_production.json'))
+		@staging_data = JSON.parse(File.read('first_import/sentry_export_staging.json'))
+		@merged_data 		= JSON.parse(File.read('02-16-2022.13.26.01_merged_export.json'))
+=end
+		@prod_data 	= JSON.parse(File.read('second_import/second_do_sentry_export_production.json'))
+		@staging_data = JSON.parse(File.read('second_import/second_do_sentry_export_staging.json'))
+		@merged_data 		= JSON.parse(File.read('03-07-2022.11.54.35_merged_export.json'))
+	end
+
+	def compare
+		compare_teams
+		compare_projects
+		compare_projectoptions_rules_keys
+	end
+
+	def compare_teams
+		prod_teams = prod_data.select{|entry| entry['model'] == 'sentry.team'}
+		staging_teams = staging_data.select{|entry| entry['model'] == 'sentry.team'}
+		merged_teams = merged_data.select{|entry| entry['model'] == 'sentry.team'}
+		found_teams = {}
+
+		prod_teams.each do |prod_team|
+			prod_slug = prod_team['fields']['slug']
+			found_teams[prod_slug] = false
+			merged_teams.each do |merged_team|
+				merged_slug = merged_team['fields']['slug']
+				if found_teams[prod_slug]
+					next
+				elsif prod_slug == merged_slug
+					found_teams[prod_slug] = true
+					next
+				end
+			end
+		end
+
+		staging_teams.each do |staging_team|
+			staging_slug = staging_team['fields']['slug']
+			found_teams[staging_slug] = false
+			merged_teams.each do |merged_team|
+				merged_slug = merged_team['fields']['slug']
+				if found_teams[staging_slug]
+					next
+				elsif staging_slug == merged_slug
+					found_teams[staging_slug] = true
+					next
+				end
+			end
+		end
+
+		found_teams.each do |slug, _|
+			if !found_teams[slug]
+				raise "did not find slug #{slug}"
+			end
+		end
+		puts "Teams compared and successfully merged: #{merged_teams.size}"
+		puts "----------------------------"
+	end
+
+	def compare_projects
+		prod_projects = prod_data.select{|entry| entry['model'] == 'sentry.project'}
+		staging_projects = staging_data.select{|entry| entry['model'] == 'sentry.project'}
+		merged_projects = merged_data.select{|entry| entry['model'] == 'sentry.project'}
+		found_projects = {}
+
+ 		prod_projects.each do |prod_project|
+			prod_slug = prod_project['fields']['slug']
+			found_projects[prod_slug] = false
+			merged_projects.each do |merged_project|
+				merged_slug = merged_project['fields']['slug']
+				if found_projects[prod_slug]
+					next
+				elsif prod_slug == merged_slug
+					found_projects[prod_slug] = true
+					next
+				end
+			end
+		end
+
+		found_projects.each do |slug, _|
+			if !found_projects[slug]
+				raise "did not find slug #{slug}"
+			end
+		end
+		puts "Projects compared and successfully merged: #{merged_projects.size}"
+		puts "----------------------------"
+	end
+
+	# select all projects in prod
+	# for each proj, use the pk to select associated project options (select ['fields']['project'] == proj_pk)
+	#
+	# do the same for staging
+	# 
+	# do the same for merged
+	# 
+	# for each prod_proj
+	#   find the associated merged project by comparing slugs
+	#   for each of their projectoptions, compare the ['field']['value']
+	def compare_projectoptions_rules_keys
+		prod_projects = prod_data.select{|entry| entry['model'] == 'sentry.project'}
+		staging_projects = staging_data.select{|entry| entry['model'] == 'sentry.project'}
+		merged_projects = merged_data.select{|entry| entry['model'] == 'sentry.project'}
+
+		prod_mapping = []
+		prod_projects.each do |prod_proj|
+			associated_vals = {}
+			options = prod_data.select{|entry| entry['model'] == 'sentry.projectoption' && entry['fields']['project'] == prod_proj['pk']}
+			rules = prod_data.select{|entry| entry['model'] == 'sentry.rule' && entry['fields']['project'] == prod_proj['pk']}
+			keys = prod_data.select{|entry| entry['model'] == 'sentry.projectkey' && entry['fields']['project'] == prod_proj['pk']}
+			associated_vals[prod_proj['fields']['slug']] = {
+				options: options,
+				rules: rules,
+				keys: keys
+			}
+			prod_mapping << associated_vals
+		end
+
+		staging_mapping = []
+		staging_projects.each do |staging_proj|
+			associated_vals = {}
+			options = staging_data.select{|entry| entry['model'] == 'sentry.projectoption' && entry['fields']['project'] == staging_proj['pk']}
+			rules = staging_data.select{|entry| entry['model'] == 'sentry.rule' && entry['fields']['project'] == staging_proj['pk']}
+			keys = staging_data.select{|entry| entry['model'] == 'sentry.projectkey' && entry['fields']['project'] == staging_proj['pk']}
+			associated_vals[staging_proj['fields']['slug']] = {
+				options: options,
+				rules: rules,
+				keys: keys
+			}
+			staging_mapping << associated_vals
+		end
+
+		merged_mapping = []
+		merged_projects.each do |merged_proj|
+			associated_vals = {}
+			options = merged_data.select{|entry| entry['model'] == 'sentry.projectoption' && entry['fields']['project'] == merged_proj['pk']}
+			rules = merged_data.select{|entry| entry['model'] == 'sentry.rule' && entry['fields']['project'] == merged_proj['pk']}
+			keys = merged_data.select{|entry| entry['model'] == 'sentry.projectkey' && entry['fields']['project'] == merged_proj['pk']}
+			associated_vals[merged_proj['fields']['slug']] = {
+				options: options,
+				rules: rules,
+				keys: keys
+			}
+			merged_mapping << associated_vals
+		end
+
+
+		########################################
+		########################################
+		##### COMPARE OPTIONS ##################
+		########################################
+		########################################
+
+		merged_options = merged_data.select{|entry| entry['model'] == 'sentry.projectoption'}
+
+		prod_mapping.each do |data_prod|
+			slug_prod = data_prod.first.first
+			equivalent_merged_project_data = merged_mapping.find{|merged_proj| merged_proj.first.first == slug_prod}[slug_prod]
+			data_prod[slug_prod][:options].each do |prod_opt|
+				matched_opt = equivalent_merged_project_data[:options].find{|merged_opt| prod_opt['fields']['value'] == merged_opt['fields']['value']}
+				if !matched_opt
+					raise "Could not match project options for project #{slug_prod}"
+				end
+			end
+		end
+
+		staging_mapping.each do |data_staging|
+			slug_staging = data_staging.first.first
+			if prod_mapping.find{|data_prod| data_prod[slug_staging]}
+				next
+			end
+			# puts "Unique staging project #{slug_staging}"
+			equivalent_merged_project_data = merged_mapping.find{|merged_proj| merged_proj.first.first == slug_staging}[slug_staging]
+			data_staging[slug_staging][:options].each do |staging_opt|
+				matched_opt = equivalent_merged_project_data[:options].find{|merged_opt| staging_opt['fields']['value'] == merged_opt['fields']['value']}
+				if !matched_opt
+					raise "Could not match project options for project #{slug_staging}"
+				end
+			end
+		end
+
+		puts "Projectoptions compared and successfully merged: #{merged_options.size}"
+		puts "----------------------------" 
+
+		########################################
+		########################################
+		##### COMPARE RULES ####################
+		########################################
+		########################################
+
+		merged_rules = merged_data.select{|entry| entry['model'] == 'sentry.rule'}
+
+		prod_mapping.each do |data_prod|
+			slug_prod = data_prod.first.first
+			equivalent_merged_project_data = merged_mapping.find{|merged_proj| merged_proj.first.first == slug_prod}[slug_prod]
+			data_prod[slug_prod][:rules].each do |prod_rule|
+				matched_rule = equivalent_merged_project_data[:rules].find{|merged_rule| prod_rule['fields']['value'] == merged_rule['fields']['value']}
+				if !matched_rule
+					raise "Could not match Rules for project #{slug_prod}"
+				end
+			end
+		end
+
+		staging_mapping.each do |data_staging|
+			slug_staging = data_staging.first.first
+			if prod_mapping.find{|data_prod| data_prod[slug_staging]}
+				next
+			end
+			# puts "Unique staging project #{slug_staging}"
+			equivalent_merged_project_data = merged_mapping.find{|merged_proj| merged_proj.first.first == slug_staging}[slug_staging]
+			data_staging[slug_staging][:rules].each do |staging_rule|
+				matched_rule = equivalent_merged_project_data[:rules].find{|merged_rule| staging_rule['fields']['value'] == merged_rule['fields']['value']}
+				if !matched_rule
+					raise "Could not match Rules for project #{slug_staging}"
+				end
+			end
+		end
+
+		puts "Rules compared and successfully merged: #{merged_rules.size}"
+		puts "----------------------------" 
+
+		########################################
+		########################################
+		##### COMPARE KEYS #####################
+		########################################
+		########################################
+
+		merged_keys = merged_data.select{|entry| entry['model'] == 'sentry.projectkey'}
+
+
+		prod_mapping.each do |data_prod|
+			slug_prod = data_prod.first.first
+			equivalent_merged_project_data = merged_mapping.find{|merged_proj| merged_proj.first.first == slug_prod}[slug_prod]
+			data_prod[slug_prod][:keys].each do |prod_key|
+				matched_key = equivalent_merged_project_data[:keys].find{|merged_key| prod_key['fields']['value'] == merged_key['fields']['value']}
+				if !matched_key
+					raise "Could not match project keys for project #{slug_prod}"
+				end
+			end
+		end
+
+		staging_mapping.each do |data_staging|
+			slug_staging = data_staging.first.first
+			if prod_mapping.find{|data_prod| data_prod[slug_staging]}
+				next
+			end
+			# puts "Unique staging project #{slug_staging}"
+			equivalent_merged_project_data = merged_mapping.find{|merged_proj| merged_proj.first.first == slug_staging}[slug_staging]
+			data_staging[slug_staging][:keys].each do |staging_key|
+				matched_key = equivalent_merged_project_data[:keys].find{|merged_key| staging_key['fields']['value'] == merged_key['fields']['value']}
+				if !matched_key
+					raise "Could not match project keys for project #{slug_staging}"
+				end
+			end
+		end
+
+		puts "Project Keys compared and successfully merged: #{merged_keys.size}"
+		puts "----------------------------" 
+	end
+end
+
+Comparer.new.compare

--- a/merge_multiple_self_hosted_instances/filter_teams_and_projects.rb
+++ b/merge_multiple_self_hosted_instances/filter_teams_and_projects.rb
@@ -1,0 +1,346 @@
+require 'json'
+require 'pry'
+
+class Filterer
+  attr_reader :raw_staging, :raw_prod, :all_projects
+
+  def initialize
+=begin
+    @raw_staging     = JSON.parse(File.read('second_import/second_do_sentry_export_staging.json'))
+    @raw_prod        = JSON.parse(File.read('second_import/second_do_sentry_export_production.json'))
+    @all_projects = fetch_projects
+=end
+    @raw_staging     = JSON.parse(File.read('first_import/sentry_export_staging.json'))
+    @raw_prod        = JSON.parse(File.read('first_import/sentry_export_production.json'))
+    @all_projects = fetch_projects
+  end
+
+  def combine_data
+    teams = separated_teams
+    team_slugs = teams[:only_prod] + teams[:only_staging] + teams[:both_prod_and_staging]
+
+    projects = separated_projects
+    project_slugs = separated_projects[:only_prod] + separated_projects[:only_staging] + separated_projects[:both_prod_and_staging]
+
+    projects = get_projects_and_associated_values(project_slugs)
+    pk_standardized_projects = standardize_pk_project_data(projects)
+    
+    if !pks_standardized_corrrectly(pk_standardized_projects)
+      # only projectoptions are tested here -- as a spot check
+      raise 'Project PKs were not standardized correctly across projectoptions'
+    end
+
+
+    # edit: i don't think i need to add staging-only teams back in, this is complete already i believe
+    ##############################################
+    ##############################################
+    ##############################################
+    #### #TODO: add staging-only teams back in! ##
+    ##############################################
+    ##############################################
+    ##############################################
+
+    final_export = raw_prod
+
+    puts "Before removing from prod..."
+    puts "Number of teams: #{final_export.select{|entry| entry['model'] == 'sentry.team'}.size}"
+    puts "Number of projects: #{final_export.select{|entry| entry['model'] == 'sentry.project'}.size}"
+    puts "Number of project options: #{final_export.select{|entry| entry['model'] == 'sentry.projectoption'}.size}"
+    puts "Number of rules: #{final_export.select{|entry| entry['model'] == 'sentry.rule'}.size}"
+    puts "Number of keys: #{final_export.select{|entry| entry['model'] == 'sentry.projectkey'}.size}"
+    puts "--------------------------------------------"
+
+
+    final_export = final_export.reject do |entry|
+      ['sentry.team', 'sentry.project', 'sentry.projectoption', 'sentry.rule', 'sentry.projectkey'].include?(entry['model'])
+    end
+
+    puts "After removing from prod..."
+    puts "Number of teams: #{final_export.select{|entry| entry['model'] == 'sentry.team'}.size}"
+    puts "Number of projects: #{final_export.select{|entry| entry['model'] == 'sentry.project'}.size}"
+    puts "Number of project options: #{final_export.select{|entry| entry['model'] == 'sentry.projectoption'}.size}"
+    puts "Number of rules: #{final_export.select{|entry| entry['model'] == 'sentry.rule'}.size}"
+    puts "Number of keys: #{final_export.select{|entry| entry['model'] == 'sentry.projectkey'}.size}"
+    puts "--------------------------------------------"
+
+    pk_standardized_projects.each do |project_data|
+      final_export << project_data[:project]
+
+      project_data[:options].each do |option|
+        final_export << option
+      end
+
+      project_data[:rules].each do |rule|
+        final_export << rule
+      end
+
+      project_data[:keys].each do |key|
+        final_export << key
+      end
+    end
+
+    full_team_data(team_slugs).each do |team_data|
+      final_export << team_data
+    end
+
+    puts "After populating with merged staging/prod..."
+    puts "Number of teams: #{final_export.select{|entry| entry['model'] == 'sentry.team'}.size}"
+    puts "Number of projects: #{final_export.select{|entry| entry['model'] == 'sentry.project'}.size}"
+    puts "Number of project options: #{final_export.select{|entry| entry['model'] == 'sentry.projectoption'}.size}"
+    puts "Number of rules: #{final_export.select{|entry| entry['model'] == 'sentry.rule'}.size}"
+    puts "Number of keys: #{final_export.select{|entry| entry['model'] == 'sentry.projectkey'}.size}"
+
+
+    current_time = Time.now.strftime("%m-%d-%Y.%H.%M.%S")
+    File.open("#{current_time}_merged_export.json", "w") do |f|
+      f.write(final_export.to_json)
+    end
+
+    # afterwards can use the comparer.rb file in same directory here to
+    # programmatically check that the merge was successful
+  end
+
+  private
+
+  def human_readable_staging(field_type, unique_identifying_field)
+    matching = raw_staging.select{|entry| entry['model'] == field_type}
+    matching.map do |v|
+      v['fields'][unique_identifying_field]
+    end
+  end
+
+  def human_readable_prod(field_type, unique_identifying_field)
+    matching = raw_prod.select{|entry| entry['model'] == field_type}
+    matching.map do |v|
+      v['fields'][unique_identifying_field]
+    end
+  end
+
+  def separated_teams
+    separate_values('sentry.team', 'slug')
+  end
+
+  def separated_projects
+    separate_values('sentry.project', 'slug')
+  end
+
+  def separate_values(field_type, unique_identifying_field)
+    both_prod_and_staging = []
+    only_staging = []
+    only_prod = []
+
+    all_staging = human_readable_staging(field_type, unique_identifying_field)
+    all_prod    = human_readable_prod(field_type, unique_identifying_field)
+
+    all_prod.each do |field|
+      if all_staging.include?(field)
+        both_prod_and_staging << field
+      else
+        only_prod << field
+      end
+    end
+
+    all_staging.each do |field|
+      if !both_prod_and_staging.include?(field)
+        only_staging << field
+      end
+    end
+    # end
+
+    aggregate = {
+      field_type: field_type,
+      unique_identifying_field: unique_identifying_field,
+      both_prod_and_staging: both_prod_and_staging,
+      only_staging: only_staging,
+      only_prod: only_prod
+    }
+
+    puts "-----------------"
+    puts "Field: #{field_type}"
+    puts "ONLY staging count: #{aggregate[:only_staging].size}"
+    puts "ONLY prod count: #{aggregate[:only_prod].size}"
+    puts "BOTH prod and staging count: #{aggregate[:both_prod_and_staging].size}"
+    puts "TOTAL unique count: #{aggregate[:only_prod].size + aggregate[:only_staging].size + aggregate[:both_prod_and_staging].size}"
+
+    return aggregate
+  end
+
+  def full_team_data(team_slugs)
+    team_slugs.map do |team_slug|
+      prod_teams = raw_prod.select{|datum| datum['model'] == 'sentry.team'}
+      staging_teams = raw_staging.select{|datum| datum['model'] == 'sentry.team'}
+      
+      # try to find slug in prod
+      prod_record = prod_teams.find{|team| team['fields']['slug'] == team_slug}
+      staging_record = staging_teams.find{|team| team['fields']['slug'] == team_slug}
+
+      if prod_record
+        prod_record
+      elsif staging_record
+        staging_record
+      else
+        raise "could not find record for team: #{team_slug}" #shouldn't happen
+      end
+    end
+  end
+
+  # snippet to confirm that all the pks were updated successfully
+  def pks_standardized_corrrectly(pk_standardized_projects)
+    mismatched = pk_standardized_projects.select do |project|
+      pk = project[:project]['pk']
+      project[:options].select do |option|
+        option['fields']['project'] != pk
+      end.size > 1
+    end
+    mismatched.empty?
+  end
+
+  # standardize all the project-pk (primary key) values for
+  # each project, and its associated options/rules/keys
+  def standardize_pk_project_data(projects)
+    proj_count    = 1
+    options_count = 1
+    rules_count   = 1
+    keys_count    = 1
+
+    projects.map do |project|
+      project = project
+      project[:project]['pk'] = proj_count
+
+      project[:options].each do |option|
+        option['pk'] = options_count
+        option['fields']['project'] = proj_count
+        options_count += 1
+      end
+
+      project[:rules].each do |rule|
+        rule['pk'] = rules_count
+        rule['fields']['project'] = proj_count
+        rules_count += 1
+      end
+
+      project[:keys].each do |key|
+        key['pk'] = keys_count
+        key['fields']['project'] = proj_count
+        keys_count += 1
+      end
+
+      proj_count += 1
+      project
+    end
+  end
+
+  def get_projects_and_associated_values(project_slugs)
+    projects  = project_slugs.map do |slug|
+      project = get_project_data(slug)
+
+      options = fetch_projectoptions(project)
+      rules   = fetch_rules(project)
+      keys    = fetch_keys(project)
+
+      {
+        project: project,
+        options: options,
+        rules: rules,
+        keys: keys
+      }
+    end
+  end
+
+  ################################
+  #### find the projectoptions ###
+  ################################
+  def fetch_projectoptions(project)
+    prod_projectoptions     = prod_values('sentry.projectoption')
+    staging_projectoptions  = staging_values('sentry.projectoption')
+
+    project_pk = project['pk']
+    if project['environment'] == 'prod'
+      return options = prod_projectoptions.select{|po| po['fields']['project'] == project_pk}
+    elsif project['environment'] == 'staging'
+      return options = staging_projectoptions.select{|po| po['fields']['project'] == project_pk}
+    else
+      raise "should not hit this. project slug #{project['fields']['slug']}"
+    end
+  end
+
+  ################################
+  #### find the rules  ###########
+  ################################
+  def fetch_rules(project)
+    prod_rules = prod_values('sentry.rule')
+    staging_rules = staging_values('sentry.rule')
+    
+    project_pk = project['pk']
+    if project['environment'] == 'prod'
+      return prod_rules.select{|rule| rule['fields']['project'] == project_pk}
+    elsif project['environment'] == 'staging'
+      return staging_rules.select{|rule| rule['fields']['project'] == project_pk}
+    else
+      raise "should not hit this. project slug #{project['fields']['slug']}"
+    end
+  end
+
+  ######################################
+  #### find the projectkeys  ###########
+  ######################################
+  def fetch_keys(project)
+    prod_keys = prod_values('sentry.projectkey')
+    # binding.pry
+    staging_keys = staging_values('sentry.projectkey')
+    
+    # It's important to differentiate prod and staging projects here.
+    # Otherwise we end up selecting overlapping options for both prod and staging and cause bugs
+    project_pk = project['pk']
+    if project['environment'] == 'prod'
+      keys = prod_keys.select{|key| key['fields']['project'] == project_pk && key['environment'] == 'prod'}
+    elsif project['environment'] == 'staging'
+      keys = staging_keys.select{|key| key['fields']['project'] == project_pk && key['environment'] == 'staging'}
+    else
+      raise "should not hit this. project slug #{project['fields']['slug']}"
+    end
+  end
+
+  def prod_values(field_type)
+    vals = raw_prod.select{|entry| entry['model'] == field_type}
+    vals.map do |val|
+      val['environment'] = 'prod'
+      val
+    end
+  end
+
+  def staging_values(field_type)
+    vals = raw_staging.select{|entry| entry['model'] == field_type}
+    vals.map do |val|
+      val['environment'] = 'staging'
+      val
+    end
+  end
+
+  def fetch_projects
+    staging_projects  = raw_staging.select{|h| h['model'] == 'sentry.project'}
+    prod_projects     = raw_prod.select{|h| h['model'] == 'sentry.project'}
+    {
+      staging: staging_projects,
+      prod: prod_projects
+    }
+  end
+
+  def get_project_data(slug)
+    prod_record = all_projects[:prod].find{|p| p['fields']['slug'] == slug}
+    staging_record = all_projects[:staging].find{|p| p['fields']['slug'] == slug}
+
+    # if the project exists in prod as well as staging, prioritize prod version
+    if prod_record
+      prod_record['environment'] = 'prod'
+      return prod_record
+    elsif staging_record
+      staging_record['environment'] = 'staging'
+      return staging_record
+    else
+      raise "Project neither in prod nor staging (this should not happen): #{slug}"
+    end
+  end
+end
+
+Filterer.new.combine_data

--- a/sentry_alerts_migrate.py
+++ b/sentry_alerts_migrate.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import json
+import requests
+
+
+class Sentry():
+    def __init__(self, base_url, org, token):
+        self.base_url = base_url
+        self.org = org
+        self.token = token
+
+    def _get_api(self, endpoint):
+        """HTTP GET the Sentry API"""
+
+        headers = {'Authorization': f'Bearer {self.token}',
+                    'Content-Type': 'application/json',}
+        url = f'{self.base_url}{endpoint}'
+        response = requests.get(url, headers=headers)
+        return response.json()
+
+    def _get_api_pagination(self, endpoint):
+        """HTTP GET the Sentry API, following pagination links"""
+
+        headers = {'Authorization': f'Bearer {self.token}'}
+
+        results = []
+        url = f'{self.base_url}{endpoint}'
+        next = True
+        while next:
+            response = requests.get(url, headers=headers)
+            results.extend(response.json())
+
+            url = response.links.get('next', {}).get('url')
+            next = response.links.get('next', {}).get('results') == 'true'
+            if url == None:
+                next = False
+
+        return results
+    
+    def _put_api(self, endpoint, data=None):
+        """HTTP PUT the Sentry API"""
+
+        headers = {'Authorization': f'Bearer {self.token}',
+                    'Content-Type': 'application/json'}
+        url = f'{self.base_url}{endpoint}'
+        return requests.put(url, headers=headers, data=data)
+
+    def _post_api(self, endpoint, data=None):
+        """HTTP POST the Sentry API"""
+
+        headers = {'Authorization': f'Bearer {self.token}',
+                    'Content-Type': 'application/json',}
+        url = f'{self.base_url}{endpoint}'
+        return requests.post(url, headers=headers, data=data)
+
+    def _delete_api(self, endpoint):
+        """HTTP DELETE the Sentry API"""
+
+        headers = {'Authorization': f'Bearer {self.token}'}
+        url = f'{self.base_url}{endpoint}'
+
+        return requests.delete(url, headers=headers)
+
+    def get_project_slugs(self):
+        """Return a list of project slugs in this Sentry org"""
+
+        results = self._get_api(f'/api/0/organizations/{self.org}/projects/')
+        return [project.get('slug', '') for project in results]
+    
+    def create_project_issue_alert(self, project, data=None):
+        """Create a issue alert for a Sentry project"""
+
+        return self._post_api(f'/api/0/projects/{self.org}/{project}/rules/', data=data)
+
+    def create_project_metric_alert(self, project, data=None):
+        """Create a metric alert for a Sentry project"""
+
+        return self._post_api(f'/api/0/projects/{self.org}/{project}/alert-rules/', data=data)
+        
+
+    def update_project_issue_alert(self, project, alertID, data=None):
+        """Update the issue alert for a Sentry project"""
+
+        return self._put_api(f'/api/0/projects/{self.org}/{project}/rules/{alertID}/', data=data)
+
+    def update_project_metric_alert(self, project, alertID, data=None):
+        """Update the metric alert for a Sentry project"""
+        return self._put_api(f'/api/0/projects/{self.org}/{project}/alert-rules/{alertID}/', data=data)
+
+    def get_project_alerts(self, project):
+        """Return a list of alerts for Sentry project"""
+
+        return self._get_api(f'/api/0/projects/{self.org}/{project}/combined-rules/')
+
+    def delete_project_issue_alert(self, project, ruleId):
+        """Delete an alert for a Sentry project"""
+
+        return self._delete_api(f'/api/0/projects/{self.org}/{project}/rules/{ruleId}/')
+
+    def delete_project_metric_alert(self, project, ruleId):
+        """Delete an alert for a Sentry project"""
+
+        return self._delete_api(f'/api/0/projects/{self.org}/{project}/alert-rules/{ruleId}/')
+
+    def get_teams(self):
+        """Return a dictionary mapping team slugs to a set of project slugs"""
+
+        return self._get_api_pagination(f'/api/0/organizations/{self.org}/teams/')
+
+
+if __name__ == '__main__':
+    onpremise_token = os.environ['SENTRY_ONPREMISE_AUTH_TOKEN']
+    cloud_token = os.environ['SENTRY_CLOUD_AUTH_TOKEN']
+
+
+    # copy over onpremise url (e.g. http://sentry.yourcompany.com)
+    sentry_onpremise = Sentry('<ON_PREMISE_URL>',
+                              '<ON_PREMISE_ORG_SLUG>',
+                              onpremise_token)
+
+    sentry_cloud = Sentry('https://sentry.io',
+                          '<ORG_SLUG>',
+                          cloud_token)
+
+    onpremise_projects = sentry_onpremise.get_project_slugs()
+    onpremise_teams = sentry_onpremise.get_teams()
+
+    # Map team ids from on-prem to cloud so we can correctly create alerts for the 
+    # right team in cloud
+    onprem_id_slugname = {team['slug']: team['id'] for team in onpremise_teams}
+
+    #grab team id and team slug name from cloud and add it to another dictionary
+    cloud_teams = sentry_cloud.get_teams()
+    cloud_id_slugname = {team['slug']: team['id'] for team in cloud_teams}
+
+    #dictionary to hold updated team ids, it will essentially be a mapping of
+    # onprem team ids to their equivalent cloud ids
+    dictionary_with_updatedvalues = {}
+
+    #create dictionary mapping described above bere
+    for key in onprem_id_slugname:
+        dictionary_with_updatedvalues.update({onprem_id_slugname[key]: cloud_id_slugname[key]})
+
+
+    #begin iterating through on-prem projects to gather alerts to send to SaaS Sentry
+    for project in onpremise_projects:
+
+        # for each project grab alerts from on-premise and cloud Sentry
+        alerts = sentry_onpremise.get_project_alerts(project)
+
+        cloudalerts = sentry_cloud.get_project_alerts(project)
+
+        # iterate through alerts from on-prem account per project
+        # and make sure to remove the alert that exists in the SaaS
+        # project and send the alert in there
+        for alert in alerts:
+            #update the team id on the alert
+            
+            # the below is to strip the teamid value that will be replaced with the 
+            # teamid of the ids on SaaS Sentry
+            teamid = alert["owner"][5:]
+            teamid = dictionary_with_updatedvalues[teamid]
+            alert["owner"] = "team:" + str(teamid)
+
+            #to be used for modifying the alert 
+            modify = 0
+            cloud_alert_to_modify = alert
+            alertID = alert["id"]
+
+            #iterate through all SaaS Sentry alerts to see if the on-prem Sentry
+            #alert already exists, if it does, modify it but don't create new alert
+            for cloudalert in cloudalerts:
+                if (cloudalert['name'] == alert['name']):
+                    if "triggers" not in cloudalert:
+                        modify = 1
+                        #make sure alerts JSON has environment tag set and Slack workspace set
+                        cloudalert["environment"] = alert["environment"]
+                        #merge Sentry local actions with Sentry Cloud actions
+                        if (alert["actions"]!=[]):
+                            for index in range(len(alert["actions"])):
+                                #check for Slack integration, only update Workspace id
+                                if alert["actions"][index]["id"] == "sentry.integrations.slack.notify_action.SlackNotifyServiceAction":
+                                    for cloudindex in range(len(cloudalert["actions"])):
+                                        if cloudalert["actions"][cloudindex]["id"] == "sentry.integrations.slack.notify_action.SlackNotifyServiceAction":
+                                            #replace workspace number
+                                            cloudalert["actions"][cloudindex]["workspace"] = alert["actions"][index]["workspace"]
+                        cloud_alert_to_modify = cloudalert
+                        alertID = cloud_alert_to_modify["id"]
+                    
+
+                        #Can delete the alert with the two options below
+                        #1.  sentry_cloud.delete_project_metric_alert(project, cloudalert["id"])
+                        #2.  sentry_cloud.delete_project_issue_alert(project, cloudalert["id"])
+
+            #format the alert, if this is not done, you will get a 500 error back from
+            #Sentry
+            if (modify != 1):
+                temp_alert = alert
+                temp_alert.pop('id', None)
+                temp_alert.pop('dateCreated', None)
+                temp_alert.pop('createdBy', None)
+                temp_alert.pop('projects', None)
+                temp_alert.pop('type', None)
+                temp_alert.pop('dateModified', None)
+                if "triggers" in temp_alert:
+                    for value in temp_alert["triggers"]:
+                        del value["dateCreated"]
+                        del value["id"]
+                        del value["alertRuleId"]
+                        for index in range(len(value["actions"])):
+                            del value["actions"][index]["id"]
+                            del value["actions"][index]["alertRuleTriggerId"]
+                            del value["actions"][index]["dateCreated"]
+                            #update team ids for the actions
+                            if value["actions"][index]["targetType"] == "team":
+                                value["actions"][index]["targetIdentifier"]=dictionary_with_updatedvalues[value["actions"][index]["targetIdentifier"]]
+                temp_alert = json.dumps(temp_alert).replace('None', 'null')
+            else:
+                temp_alert = cloud_alert_to_modify
+                temp_alert.pop('type', None)
+                temp_alert = json.dumps(temp_alert).replace('None', 'null')
+
+            #check if the alert is a metric alert or issue alert and
+            # create/update the proper alert, updating metric alerts not supported yet
+            if "triggers" in temp_alert:
+                if modify != 1:
+                    sentry_cloud.create_project_metric_alert(project, temp_alert)
+
+            else:
+                if modify == 1:
+                    sentry_cloud.update_project_issue_alert(project, alertID, temp_alert)
+                else:
+                    sentry_cloud.create_project_issue_alert(project, temp_alert)
+
+
+

--- a/sentry_alerts_migration_check.py
+++ b/sentry_alerts_migration_check.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import json
+import requests
+
+
+class Sentry():
+    def __init__(self, base_url, org, token):
+        self.base_url = base_url
+        self.org = org
+        self.token = token
+
+    def _get_api(self, endpoint):
+        """HTTP GET the Sentry API"""
+
+        headers = {'Authorization': f'Bearer {self.token}',
+                    'Content-Type': 'application/json',}
+        url = f'{self.base_url}{endpoint}'
+        response = requests.get(url, headers=headers)
+        return response.json()
+
+    def _get_api_pagination(self, endpoint):
+        """HTTP GET the Sentry API, following pagination links"""
+
+        headers = {'Authorization': f'Bearer {self.token}'}
+
+        results = []
+        url = f'{self.base_url}{endpoint}'
+        next = True
+        while next:
+            response = requests.get(url, headers=headers)
+            results.extend(response.json())
+
+            url = response.links.get('next', {}).get('url')
+            next = response.links.get('next', {}).get('results') == 'true'
+            if url == None:
+                next = False
+
+        return results
+
+    def get_project_slugs(self):
+        """Return a list of project slugs in this Sentry org"""
+
+        results = self._get_api(f'/api/0/organizations/{self.org}/projects/')
+        return [project.get('slug', '') for project in results]
+    
+
+    def get_project_alerts(self, project):
+        """Return a list of alerts for Sentry project"""
+
+        return self._get_api(f'/api/0/projects/{self.org}/{project}/combined-rules/')
+
+    def get_teams(self):
+        """Return a dictionary mapping team slugs to a set of project slugs"""
+
+        return self._get_api_pagination(f'/api/0/organizations/{self.org}/teams/')
+
+
+if __name__ == '__main__':
+    onpremise_token = os.environ['SENTRY_ONPREMISE_AUTH_TOKEN']
+    cloud_token = os.environ['SENTRY_CLOUD_AUTH_TOKEN']
+
+
+    # copy over onpremise url (e.g. http://sentry.yourcompany.com)
+    sentry_onpremise = Sentry('<ON_PREMISE_URL>',
+                              '<ON_PREMISE_ORG_SLUG>',
+                              onpremise_token)
+
+    sentry_cloud = Sentry('https://sentry.io',
+                          '<ORG_SLUG>',
+                          cloud_token)
+
+    onpremise_projects = sentry_onpremise.get_project_slugs()
+
+    #grab teams on Sentry SaaS
+    cloud_teams = sentry_cloud.get_teams()
+
+    #count of metric alerts in on-prem
+    countofmetricalerts = 0
+
+    #count of metric alerts in cloud
+    countofmetricalertscloud = 0
+
+
+    #begin iterating through on-prem projects to gather alerts to send to SaaS Sentry
+    for project in onpremise_projects:
+
+        # for each project grab alerts from on-premise and cloud Sentry
+        alerts = sentry_onpremise.get_project_alerts(project)
+
+        cloudalerts = sentry_cloud.get_project_alerts(project)
+
+        # iterate through alerts from on-prem account per project
+        # and make sure to count it
+        for alert in alerts:
+            if ("triggers" in alert):
+                countofmetricalerts += 1
+
+            #iterate through all SaaS Sentry alerts to see if the on-prem Sentry
+            #alert already exists, if it does, count it
+            for cloudalert in cloudalerts:
+                if (cloudalert['name'] == alert['name'] and "triggers" in cloudalert):
+                    countofmetricalertscloud += 1
+                    
+
+    #compare on-prem alerts with cloud alerts
+    if (countofmetricalerts == countofmetricalertscloud):
+        print("Successful migration")
+    else:
+        print("Migration was not successful") 
+            
+
+
+

--- a/sentry_member_team_map.py
+++ b/sentry_member_team_map.py
@@ -114,7 +114,7 @@ if __name__ == '__main__':
                     found=1
                     break
 
-        #Make a new user if not found in new org, email must match what is on Okta
+        #Make a new user if not found in new org
         if (found == 0):
 
             #Create new user

--- a/sentry_member_team_map_withoutSCIM.py
+++ b/sentry_member_team_map_withoutSCIM.py
@@ -41,7 +41,6 @@ class Sentry():
 
     def get_teams(self):
         """Return a dictionary mapping team slugs to a set of project slugs"""
-
         results = self._get_api_pagination(f'/api/0/organizations/{self.org}/teams/')
         return {team['slug']: team for team in results if 'slug' in team}
 
@@ -63,12 +62,29 @@ class Sentry():
         teammember = self._post_api(f'/api/0/organizations/{self.org}/members/', data)
         return teammember.json()
 
-    def update_team_reg(self, memberid, teamname):
+    def update_team_reg(self, memberid, teamname, member_email):
         """Update team attributes"""
 
         result = self._post_api(f'/api/0/organizations/{self.org}/members/{memberid}/teams/{teamname}/')
-        return result
+        if result.status_code in [201,204]:
+            logger.info("Team '%s' has assigned cloud member '%s'" % (team,member_email))
+            return result
+        else:
+            logger.warning(f'\n[WARN] Could not assign member {member_email} to team {teamname}. Status code {result.status_code}\n')
 
+def prompt_user_to_confirm_dry_run_mode(is_dryrun_mode, action_to_take):
+    print("\n")
+    if is_dryrun_mode:
+        print(f'Running in DRYRUN MODE. About to {action_to_take}.')
+    else:
+        print(f'Running for real (not dry run mode). About to {action_to_take}. This will cause database changes to be made to SaaS.')
+
+    selection = input(f"Continue? y/n:\n")
+    if selection != "y":
+        print("'y' not selected. Exiting program.")
+        sys.exit()
+    else:
+        print("\n")
 
 
 if __name__ == '__main__':
@@ -77,12 +93,23 @@ if __name__ == '__main__':
         format='%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s', 
         datefmt='%Y-%m-%d:%H:%M:%S', level=logging.DEBUG, filemode='a')
     logger = logging.getLogger(__name__)
+    handler = logging.StreamHandler(sys.stdout)
+    logger.addHandler(handler)
     logger.info(">>> Script started")
     onpremise_token = os.environ['SENTRY_ONPREMISE_AUTH_TOKEN']
     onpremise_url = os.environ['ON_PREMISE_URL']
     onpremise_slug = os.environ['ON_PREMISE_ORG_SLUG']
     cloud_token = os.environ['SENTRY_CLOUD_AUTH_TOKEN']
     cloud_slug = os.environ['ORG_SLUG']
+    # dryrun_member_creation = True #change to false when ready to create members in SaaS for real
+    dryrun_associate_members_teams = True #change to false when ready to associate members/teams in SaaS for real
+
+    if dryrun_associate_members_teams:
+        logger.info("=========================\nRunning in DRY RUN MODE\n=========================")
+    else:
+        logger.info("=========================\nRunning for real\n=========================")
+
+    # prompt_user_to_confirm_dry_run_mode(dryrun_member_creation, "Recreate on-premise members in SaaS")
 
     onpremise_url = onpremise_url.strip("/"); #removes trailing slash '/' of the URL if needed
 
@@ -107,7 +134,8 @@ if __name__ == '__main__':
     logger.info("Get cloud members completed.")
 
     #get id of old account and store it along with email in a common dictionary, i.e. updated_ids_dict
-    logger.info("Checking for duplicate users...")
+    logger.info("\n================================================")
+    logger.info("...Checking for duplicate users in cloud/on-prem. These users may need to be added via Sentry UI...\n")
     for member in onpremise_members:
         found = 0
         # Check if any onpremise members already exist as cloud members
@@ -117,7 +145,7 @@ if __name__ == '__main__':
                 #update id in common dictionary to use pre-existing cloud member's id
                 updated_ids_dict[member.get('email')] = cloudmember.get('id')
                 found = 1
-                logger.info("Duplicate member found! They already exist in cloud: %s" % (member.get('email')))
+                # logger.info("Member already exists in cloud: %s" % (member.get('email')))
                 break
 
         # Make a new user if not found in cloud, email must match what is on Okta
@@ -130,13 +158,28 @@ if __name__ == '__main__':
             }
             data["userName"] = member.get('email')
             data['email'] = member.get('email')
-            newuser = sentry_cloud.create_team_member(data)
-            logger.info("Created new user (userName, role) in cloud: %s, %s" % (data["userName"], data['role']))
-            #get id of new user
-            newuser_id = newuser.get("id")
             
-            #update id in common dictionary
-            updated_ids_dict[member['email']] = newuser_id
+            logger.info(f'[INFO] - onprem user "{data["userName"]}" ("{data["role"]}" role) does not exist in cloud')
+
+            # Member creation via API is not permitted at this time; commenting out.
+            # if dryrun_member_creation:
+            #     logger.info(f'DRYRUN MODE - would have created onprem user "{data["userName"]}" ("{data["role"]}" role) in cloud')
+            # else:
+                # newuser = sentry_cloud.create_team_member(data)
+                # if "userName" in newuser:
+                #     logger.info("Created new user (userName, role) in cloud: %s, %s" % (data["userName"], data['role']))
+                # else:
+                #     # this may actually be expected since I no longer see a documented endpoint for
+                #     # creating new Sentry members via API
+                #     logger.info(f'\n[ERROR] Could not create user - {data["userName"]} - {newuser}\n')
+
+                # #get id of new user
+                # newuser_id = newuser.get("id")
+                
+                # #update id in common dictionary
+                # updated_ids_dict[member['email']] = newuser_id
+
+    prompt_user_to_confirm_dry_run_mode(dryrun_associate_members_teams, "assign users to teams.\nNote: Users would be assigned to the same team names as they had from onprem. The teams must already exist on the cloud Sentry.")
 
     # By now, all onpremise_members should have updated ids for the new org,
     # this should be stored in the new dictionary
@@ -145,23 +188,36 @@ if __name__ == '__main__':
     # Teams exist in both spots, team names must exist in both spots but
     # ids will be different, as a result, team name must be used because
     # that's whats in common
-    userInput = input("\nWould you like to assign cloud users to teams?\nNote: Users would be assigned to the same team names as they had from onprem. The teams must already exist on the cloud Sentry.\n(y/n): ")
+    # userInput = input("\nWould you like to assign cloud users to teams?\nNote: Users would be assigned to the same team names as they had from onprem. The teams must already exist on the cloud Sentry.\n(y/n): ")
     
-    if userInput.lower() == "y":
-        for team in onpremise_teams:
-            #update old team members with ids of new org member ids
-            for member in sentry_onpremise.get_teams_members_reg(team):
-                #onpremise team member for selected team has updated id
-                member['id'] = updated_ids_dict.get(member.get("email"))
-                
-                #update cloud team with member from on_prem team
-                if team in cloud_teams:
-                    sentry_cloud.update_team_reg(member['id'], team)
-                    logger.info("Cloud user %s has been assigned to team %s" % (member.get("email"), team))
-                else:
-                    logger.info("Team %s does not exist in cloud! Could not add user %s" % (team, member.get("email")))
-    else:
-        logger.info("Skipped assigning cloud users to corresponding onprem teams")
+    logger.info("\n================================================")
+    logger.info("\n...Preparing to assign cloud members to teams...")
 
-    logger.info("<<< Script completed")
+    # if userInput.lower() == "y":
+    for team in onpremise_teams:
+        logger.info("\n")
+        #update old team members with ids of new org member ids
+        for onprem_member in sentry_onpremise.get_teams_members_reg(team):
+            #onpremise team member for selected team has updated id
+            onprem_member['id'] = updated_ids_dict.get(onprem_member.get("email"))
+            #update cloud team with member from on_prem team
+            if team in cloud_teams:
+                onprem_member_exists_in_cloud = True in (cloud_member['email'] == onprem_member['email'] for cloud_member in cloud_members)
+                if dryrun_associate_members_teams:
+                    if onprem_member_exists_in_cloud:
+                        logger.info("DRY RUN: Team '%s' would add cloud member '%s'" % (team,onprem_member.get("email")))
+                    else:
+                        logger.info(f'[WARN] DRY RUN: Onprem user "{onprem_member["email"]}" on team "{team}" does not exist in cloud! Cannot add to cloud team {team}')
+                else:
+                    if onprem_member_exists_in_cloud:
+                        # logger.info("Adding to Team %s - cloud member %s" % (team,onprem_member.get("email")))
+                        sentry_cloud.update_team_reg(onprem_member['id'], team, onprem_member['email'])
+                    else:
+                        logger.warning(f'[WARN] ==========> onprem user "{onprem_member["email"]}" does not exist in cloud; could not add to team "{team}"!')
+            else:
+                logger.warning("[WARN] Team %s does not exist in cloud! Could not add member %s\n" % (team, onprem_member.get("email")))
+    # else:
+    #     logger.info("Skipped assigning cloud users to corresponding onprem teams")
+
+    logger.info("\n<<< Script completed")
     print("\nScript completed. Log available in ./%s" % (os.path.basename(__file__)+'.log'))

--- a/sentry_project_platformtype_setting.py
+++ b/sentry_project_platformtype_setting.py
@@ -42,15 +42,8 @@ class Sentry():
         results = self._get_api(f'/api/0/organizations/{self.org}/projects/')
         return [project.get('slug', '') for project in results]
 
-    def get_keys(self, project_slug):
-        """return the public and secret DSN links for the given project slug"""
-
-        results = self._get_api(f'/api/0/projects/{self.org}/{project_slug}/keys/')
-
-        return (results[0]['dsn']['public'], results[0]['dsn']['secret'])
-
     def get_teams(self):
-        """Return a dictionary mapping team slugs to a set of project slugs"""
+        """Return slug names for given teams"""
 
         results = self._get_api(f'/api/0/organizations/{self.org}/teams/')
 
@@ -74,8 +67,7 @@ class Sentry():
     def set_project_platform(self, project, filtervalue):
         """Update project with platform value"""
 
-        result = self._put_api(f'/api/0/projects/{self.org}/{project}/', data={"platform": filtervalue})
-        print(result)
+        return self._put_api(f'/api/0/projects/{self.org}/{project}/', data={"platform": filtervalue})
 
 def get_team_projects(teams):
     mapping = {}

--- a/sentry_project_webfilter_setting.py
+++ b/sentry_project_webfilter_setting.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-
 import requests
 
 
@@ -49,13 +48,6 @@ class Sentry():
 
         results = self._get_api_pagination(f'/api/0/organizations/{self.org}/projects/')
         return [project.get('slug', '') for project in results]
-
-    def get_keys(self, project_slug):
-        """return the public and secret DSN links for the given project slug"""
-
-        results = self._get_api_pagination(f'/api/0/projects/{self.org}/{project_slug}/keys/')
-
-        return (results[0]['dsn']['public'], results[0]['dsn']['secret'])
 
     def get_teams(self):
         """Return a dictionary mapping team slugs to a set of project slugs"""

--- a/set_project_rate_limits.py
+++ b/set_project_rate_limits.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import json
+import requests
+
+
+class Sentry():
+    def __init__(self, base_url, org, token):
+        self.base_url = base_url
+        self.org = org
+        self.token = token
+
+    def _get_api(self, endpoint):
+        """HTTP GET the Sentry API"""
+        headers = {'Authorization': f'Bearer {self.token}'}
+        url = f'{self.base_url}{endpoint}'
+        response = requests.get(url, headers=headers)
+        return response.json()
+
+    def _get_api_pagination(self, endpoint):
+        """HTTP GET the Sentry API, following pagination links"""
+
+        headers = {'Authorization': f'Bearer {self.token}'}
+
+        results = []
+        url = f'{self.base_url}{endpoint}'
+        next = True
+        while next:
+            response = requests.get(url, headers=headers)
+            results.extend(response.json())
+
+            url = response.links.get('next', {}).get('url')
+            next = response.links.get('next', {}).get('results') == 'true'
+            if url == None:
+                next = False
+
+        return results
+
+    def _put_api(self, endpoint, data=None):
+        """HTTP PUT the Sentry API"""
+
+        headers = {'Authorization': f'Bearer {self.token}',
+                'Content-Type': 'application/json',}
+        url = f'{self.base_url}{endpoint}'
+        return requests.put(url, headers=headers, data=data)
+
+    def get_project_slugs(self):
+        """Return a list of project slugs in this Sentry org"""
+
+        results = self._get_api_pagination(f'/api/0/projects/')
+        return [project.get('slug', '') for project in results]
+    
+
+    def set_project_rate_limits(self, project, keyId, data=None):
+        """Set a Sentry project limit"""
+
+        return self._put_api(f'/api/0/projects/{self.org}/{project}/keys/{keyId}/', data=data)
+
+    def get_keys(self, project_slug):
+        """return all the keys for the given project slug"""
+
+        results = self._get_api(f'/api/0/projects/{self.org}/{project_slug}/keys/')
+
+        return results
+
+    def get_teams(self):
+        """Return a dictionary mapping team slugs to a set of project slugs"""
+
+        return self._get_api_pagination(f'/api/0/organizations/{self.org}/teams/')
+
+
+if __name__ == '__main__':
+    cloud_token = os.environ['SENTRY_CLOUD_AUTH_TOKEN']
+
+
+    # copy over cloud url (e.g. http://sentry.yourcompany.com)
+    sentry_cloud = Sentry('https://sentry.io',
+                              '<CLOUD_ORG_SLUG>',
+                              cloud_token)
+
+    #grab project slugs
+    cloud_projects = sentry_cloud.get_project_slugs()
+
+
+    #begin iterating through projects to set DSN limits for SaaS Sentry
+    for project in cloud_projects:
+
+
+         # iterate through keys
+        keys = sentry_cloud.get_keys(project)
+        for key in keys:
+            #strip out the key
+            key = key['dsn']['public']
+            key = key[8:40]
+
+
+            #Set the DSN rate limit
+            data = {
+                    "rateLimit": {"count": 1000, "window": 60}
+                    }
+
+            #for each project, set the DSN rate limit on
+            #a per project level
+            sentry_cloud.set_project_rate_limits(project, key, json.dumps(data))
+
+
+
+        


### PR DESCRIPTION
- Dry run mode for member/team mapping script (dry run is on by default). Prompt user to continue or exit based on the current mode.
- Comment out creation of members in SaaS who do not exist on-prem (API permissions don't currently allow for this and API calls were failing silently)
- `WARN` when there was a mismatch in cloud and on-prem members, and teams.

# Example output when run in dry-run mode

<img width="894" alt="Screen Shot 2022-11-15 at 11 55 48 AM" src="https://user-images.githubusercontent.com/12092849/202014554-7e22b95d-8bf8-4765-b829-a4b551f64d8f.png">

# Example output when run for real (dry-run mode off)
<img width="894" alt="Screen Shot 2022-11-15 at 12 05 27 PM" src="https://user-images.githubusercontent.com/12092849/202014992-df800942-3ddc-43ac-9a4d-f819b15a6970.png">
